### PR TITLE
Nth order butterworth and linkwitz-riley filters

### DIFF
--- a/filter/ddsp/filter/allpass.d
+++ b/filter/ddsp/filter/allpass.d
@@ -61,6 +61,7 @@ public:
 unittest
 {
     import dplug.core.nogc;
+    import ddsp.effect : testEffect;
     
     Allpass!float f = mallocNew!(Allpass!float)();
     f.setSampleRate(44100);

--- a/filter/ddsp/filter/highpass.d
+++ b/filter/ddsp/filter/highpass.d
@@ -6,7 +6,12 @@
 module ddsp.filter.highpass;
 
 import ddsp.filter.biquad;
+import ddsp.effect : AudioEffect;
+import ddsp.filter.lowpass : calculateQValuesForButterworth;
+
 import std.math;
+
+import dplug.core : mallocNew, mallocSlice;
 
 /// First order highpass filter
 class HighpassO1(T) : BiQuad!T
@@ -52,11 +57,12 @@ public:
     override void calcCoefficients() nothrow @nogc
     {
         _thetac = 2 * PI * _frequency / _sampleRate;
-        _d0 = 1 / _q;
-        _beta = 0.5 * (1 - (_d0 / 2) * sin(_thetac)) / (1 + (_d0 / 2) * sin(_thetac));
+        _d = 1 / _q;
+        _beta = 0.5 * (1 - (_d / 2) * sin(_thetac)) / (1 + (_d / 2) * sin(_thetac));
         _gamma = (0.5 + _beta) * cos(_thetac);
-        _a1 = -(0.5 + _beta + _gamma);
-        _a0 = (-_a1) / 2.0;
+
+        _a0 = (0.5 + _beta + _gamma) / 2;
+        _a1 = - (0.5 + _beta + _gamma);
         _a2 = _a0;
         _b1 = -2.0 * _gamma;
         _b2 = 2.0 * _beta;
@@ -67,6 +73,7 @@ private:
     float _q = 0.707f;
     float _beta;
     float _gamma;
+    float _d;
 }
 
 unittest
@@ -144,4 +151,165 @@ private:
 unittest
 {
     LinkwitzRileyHP!float linkwitzRileyHP = new LinkwitzRileyHP!float();
+}
+
+class LinkwitzRileyHPNthOrder(T) : AudioEffect!T
+{
+public:
+nothrow:
+@nogc:
+
+    this(int order)
+    {
+        assert(order % 2 == 0, "LR filter order must be even");
+        _order = order;
+
+        _bw1 = mallocNew!(ButterworthHPNthOrder!T)(order / 2);
+        _bw2 = mallocNew!(ButterworthHPNthOrder!T)(order / 2);
+    }
+
+    void setFrequency(float frequency)
+    {
+        if(frequency != _frequency)
+        {
+            _frequency = frequency;
+            _bw1.setFrequency(_frequency);
+            _bw2.setFrequency(_frequency);
+        }
+    }
+
+    override float getNextSample(const(float) input)
+    {
+        return _bw2.getNextSample(_bw1.getNextSample(input));
+    }
+
+    override void reset()
+    {
+        _bw1.reset();
+        _bw2.reset();
+    }
+
+    override void setSampleRate(float sampleRate)
+    {
+        if(sampleRate != _sampleRate)
+        {
+            _sampleRate = sampleRate;
+            _bw1.setSampleRate(_sampleRate);
+            _bw2.setSampleRate(_sampleRate);
+        }
+    }
+
+private:
+    ButterworthHPNthOrder!T _bw1;
+    ButterworthHPNthOrder!T _bw2;
+
+    int _order;
+    float _frequency;
+}
+
+unittest
+{
+    LinkwitzRileyHPNthOrder!float lr8thOrder = mallocNew!(LinkwitzRileyHPNthOrder!float)(8);
+    lr8thOrder.setSampleRate(44100);
+    lr8thOrder.setFrequency(400);
+    
+}
+
+class ButterworthHPNthOrder(T) : AudioEffect!T
+{
+public:
+nothrow:
+@nogc:
+    this(int order)
+    {
+        _order = order;
+        _secondOrderHighpasses = mallocSlice!(HighpassO2!float)(order / 2);
+        foreach(index; 0..(order / 2))
+        {
+            _secondOrderHighpasses[index] = mallocNew!(HighpassO2!float)();
+        }
+    }
+
+    void setFrequency(float frequency)
+    {
+        if(frequency != _frequency)
+        {
+            _frequency = frequency;
+            float[] qValues = calculateQValuesForButterworth(_order);
+            foreach(index, hpf; _secondOrderHighpasses)
+            {
+                float qValue = qValues[index];
+                hpf.setFrequency(frequency);
+                hpf.setQualityFactor(qValue);
+            }
+        }
+    }
+
+    override float getNextSample(const(float) input)
+    {
+        float output = input;
+        foreach(hpf; _secondOrderHighpasses)
+        {
+            output = hpf.getNextSample(output);
+        }
+        return output;
+    }
+
+    override void reset()
+    {
+        foreach(hpf; _secondOrderHighpasses)
+        {
+            if(hpf)
+            {
+                hpf.reset();
+            }
+        }
+    }
+
+    override void setSampleRate(float sampleRate)
+    {
+        if(sampleRate != _sampleRate)
+        {
+            _sampleRate = sampleRate;
+            foreach(index; 0.._secondOrderHighpasses.length)
+            {
+                _secondOrderHighpasses[index].setSampleRate(sampleRate);
+            }
+        }
+    }
+
+private:
+    HighpassO2!float[] _secondOrderHighpasses;
+
+    int _order;
+    float _frequency;
+}
+
+unittest
+{
+    import std.stdio;
+    writeln("****************************");
+    writeln("* Butterworth Filter tests *");
+    writeln("****************************");
+
+    writeln("Q Value Calculations");
+    float[] actual = calculateQValuesForButterworth(4);
+    float[] expected = [0.541196100146197, 1.3065629648763764];
+    assert( actual ==  expected, "Failed for order = 4");
+    writeln("passed for order = 4");
+
+    ButterworthHPNthOrder!float butterworth4 = mallocNew!(ButterworthHPNthOrder!float)(4);
+    butterworth4.setSampleRate(44100.0f);
+    butterworth4.setFrequency(10000);
+
+    float[] impulse = [1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f];
+    float[] hpfOutput = [];
+    foreach(sample; impulse)
+    {
+        hpfOutput ~= butterworth4.getNextSample(sample);
+    }
+
+    writeln("Butterworth N=4 Output:");
+    writeln(hpfOutput);
+    
 }


### PR DESCRIPTION
This adds support for nth-order LR and Butterworth filters.  This is useful for crossovers as well as for instances where a steep cutoff is desired.

In addition to this, the HighpassO2 filter was fixed.  The calculations of the biquad coefficients were incorrect.