### PR TITLE
Implement 1st order and nth order allpass filters

### DIFF
--- a/util/ddsp/util/envelope.d
+++ b/util/ddsp/util/envelope.d
@@ -158,7 +158,7 @@ unittest
         foreach(val; values)
         {
             auto result = rmsDetector.detect(val);
-            writeln(result);
+            // writeln(result);
         }
     }
 
@@ -170,7 +170,7 @@ unittest
         foreach(val; values)
         {
             auto result = peakDetector.detect(val);
-            writeln(result);
+            // writeln(result);
         }
     }
 }


### PR DESCRIPTION
Added support for 1st order allpass filters as well as nth order allpass filters.  These will be very useful for crossovers created using a steeper cutoff.